### PR TITLE
Add nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Feel free to submit a pull request. The software that you add must strictly adhe
 
 ## Web Servers
   - [Apache HTTP Server](https://httpd.apache.org/) - Secure, efficient, and extensible web server. ([Apache License 2.0](http://www.apache.org/licenses/))
+  - [nginx](https://nginx.org/) - A HTTP and reverse proxy server, a mail proxy server, and a generic TCP/UDP proxy server. ([2-clause BSD-like license](https://nginx.org/LICENSE))
   - [ZeroNet](https://zeronet.io/) - Decentralized websites using Bitcoin cryptography and the BitTorrent network. ([GNU GPLv2](https://raw.githubusercontent.com/HelloZeroNet/ZeroNet/master/LICENSE))
 
 ---


### PR DESCRIPTION
According to Netcraft, nginx served or proxied 27.83% busiest sites in November 2016.

Success stories:
 - https://openconnect.netflix.com/de_de/software/
 - https://www.nginx.com/case-studies/nginx-wordpress-com/?_ga=1.6997938.1809491419.1481206739
 - https://blog.fastmail.com/2007/01/04/webimappop-frontend-proxies-changed-to-nginx/

Thus, it should be considered awesome