### PR TITLE
GCC also supports D officially

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: Some of these may contain or allow installation of nonfree software. See t
 
 ### Programming
 
-- [GNU Compiler Collection](https://www.gnu.org/software/gcc/) - Compiler for C, C++, Objective-C, Fortran, Ada, and Go. ([GNU GPLv3](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=COPYING3;h=94a9ed024d3859793618152ea559a168bbcbb5e2;hb=f0cd56a4ae4b7114ad5df0d34fa1d75c8d3469dc))
+- [GNU Compiler Collection](https://www.gnu.org/software/gcc/) - Compiler for C, C++, Objective-C, Fortran, Ada, Go, and D. ([GNU GPLv3](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=COPYING3;h=94a9ed024d3859793618152ea559a168bbcbb5e2;hb=f0cd56a4ae4b7114ad5df0d34fa1d75c8d3469dc))
 
 ### Scientific Work
 


### PR DESCRIPTION
reference: [https://lwn.net/Articles/726130/](https://lwn.net/Articles/726130/).