### PR TITLE
Add Dnote to the "Web Application" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 
 ### Web Applications
 
+- [Dnote](https://dnote.io/) - A simple, end-to-end encrypted notebook for privacy. ([GNU AGPLv3](https://framagit.org/chocobozzz/PeerTube/blob/develop/LICENSE))
 - [Etherpad](http://etherpad.org/) - Collaborative document editing in real-time. ([Apache License 2.0](https://github.com/ether/etherpad-lite/blob/develop/LICENSE))
 - [Ghost](https://ghost.org/) - Hackable platform for building and running online publications. ([MIT](https://github.com/TryGhost/Ghost/blob/master/LICENSE))
 - [GitLab](https://about.gitlab.com/installation/) - Git repository manager for the entire code lifecycle. ([MIT](https://gitlab.com/gitlab-org/gitlab-ce/raw/master/LICENSE))


### PR DESCRIPTION
This PR adds [dnote](https://github.com/dnote/dnote) to the "Web Application" section of the list. It is a free and open source note-taking software under AGPLv3. I have followed the alphabetical order.