### PR TITLE
Add ExifCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 ### Graphics
 
 - [Blender](https://www.blender.org/) - 3D creation suite for modeling, simulation, and animation. ([GNU GPLv2+](https://www.blender.org/about/license/))
+- [ExifCleaner](https://exifcleaner.com/) - GUI app to remove exif metadata from images and videos with simple drag and drop. ([MIT](https://github.com/szTheory/exifcleaner/blob/master/LICENSE))
 - [GIMP](http://www.gimp.org/) - Image manipulation software. ([GNU GPLv3](https://www.gimp.org/about/COPYING))
 - [Inkscape](https://inkscape.org) - Professional vector graphics editor for all platforms. ([GNU GPL](https://bazaar.launchpad.net/~inkscape.dev/inkscape/trunk/view/head:/COPYING))
 - [Krita](https://krita.org) - Painting program made by artists. ([GNU GPLv3](https://phabricator.kde.org/source/krita/browse/master/COPYING))


### PR DESCRIPTION
ExifCleaner is a free and opensource desktop GUI app to remove metadata from images and videos using simple drag and drop operation. It's been out for several months and has numerous daily users on Linux, Mac, and Windows including myself. I've fixed the major reported bugs and it's feature stable. I built this app because I couldn't find any good free and open source alternatives that had such a convenient workflow.