### PR TITLE
add the keploy in the READNE

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Software in this list is distributed under terms that allow anyone to use, modif
 - [Healthchecks](https://healthchecks.io/) - Cron job monitoring service. ([BSD 3-clause](https://github.com/healthchecks/healthchecks/blob/master/LICENSE))
 - [Inventaire](https://inventaire.io/welcome) - Share books with friends and communities. ([GNU AGPLv3](https://github.com/inventaire/inventaire/blob/master/LICENSE.md))
 - [Lobsters](https://lobste.rs/) - Link aggregation and discussion with downvote explanations. ([BSD 3-clause](https://github.com/lobsters/lobsters/blob/master/LICENSE))
+- [Keploy](https://keploy.io/) - Open-source API testing platform that generates tests and mocks from API calls. ([Apache-2.0](https://github.com/keploy/keploy/blob/main/LICENSE))
 - [Mastodon](https://joinmastodon.org/) - Decentralized social network server. ([GNU AGPLv3](https://github.com/tootsuite/mastodon/blob/master/LICENSE))
 - [MediaGoblin](http://mediagoblin.org/) - Publishing platform for all types of media. ([GNU AGPLv3](http://mediagoblin.org/))
 - [MediaWiki](https://www.mediawiki.org) - Wiki software that can organize and serve large amounts of frequently accessed data. ([GNU GPLv2+](https://www.mediawiki.org/wiki/Copyright))


### PR DESCRIPTION
### Add Keploy to Web Applications

This PR adds Keploy to the Web Applications section.

- Name: Keploy
- Website: https://keploy.io/
- Description: Open-source API testing platform that generates tests and mocks from API calls.
- License: Apache-2.0 (https://github.com/keploy/keploy/blob/main/LICENSE)

Why:
- Free and open-source (Apache-2.0).
- Fits the Web Applications category.
- Entry follows the list’s style and is placed in alphabetical order.

Checklist:
- [x] Uses HTTPS links
- [x] Includes license
- [x] Concise, one-line description
- [x] No duplicates
- [x] Alphabetical order