### PR TITLE
Add DevToolbox - free private developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Software in this list is distributed under terms that allow anyone to use, modif
 ### Web Applications
 
 - [Cloverleaf](https://cloverleaf.app) - An open source app to replace your password manager without storing your passwords anywhere. ([MIT](https://github.com/cloverleaf/web/blob/master/LICENSE))
+- [DevToolbox](https://dannycranmer.github.io/devtoolbox/) - Free browser-based developer tools including JSON formatter, JWT decoder, Base64 encoder, and more. No data leaves your device. ([MIT](https://github.com/dannycranmer/devtoolbox/blob/main/LICENSE))
 - [Dnote](https://www.getdnote.com/) - A simple command line notebook with multi-device sync and web interface. ([GNU AGPLv3](https://github.com/dnote/dnote/blob/master/licenses/AGPLv3.txt))
 - [DocuSeal](https://www.docuseal.co/) - A platform to fill and sign digital documents. ([GNU AGPLv3](https://github.com/docusealco/docuseal/blob/master/LICENSE))
 - [Etherpad](http://etherpad.org/) - Collaborative document editing in real-time. ([Apache License 2.0](https://github.com/ether/etherpad-lite/blob/develop/LICENSE))


### PR DESCRIPTION
**DevToolbox** — A free suite of 25 browser-based developer tools (JSON formatter, JWT decoder, Base64 encoder, regex tester, and more).

All tools run entirely client-side — no data is ever sent to a server.

- **Website:** https://dannycranmer.github.io/devtoolbox/
- **Source:** https://github.com/dannycranmer/devtoolbox
- **License:** MIT