### PR TITLE
Add ImageToolkit - free private image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Software in this list is distributed under terms that allow anyone to use, modif
 - [Blender](https://www.blender.org/) - 3D creation suite for modeling, simulation, and animation. ([GNU GPLv2+](https://www.blender.org/about/license/))
 - [ExifCleaner](https://exifcleaner.com/) - GUI app to remove exif metadata from images and videos with simple drag and drop. ([MIT](https://github.com/szTheory/exifcleaner/blob/master/LICENSE))
 - [GIMP](http://www.gimp.org/) - Image manipulation software. ([GNU GPLv3](https://www.gimp.org/about/COPYING))
+- [ImageToolkit](https://dannycranmer.github.io/imagetoolkit/) - Free browser-based image tools for compression, resizing, conversion, and cropping. Files never leave your device. ([MIT](https://github.com/dannycranmer/imagetoolkit/blob/main/LICENSE))
 - [Inkscape](https://inkscape.org) - Professional vector graphics editor for all platforms. ([GNU GPL](https://bazaar.launchpad.net/~inkscape.dev/inkscape/trunk/view/head:/COPYING))
 - [Krita](https://krita.org) - Painting program made by artists. ([GNU GPLv3](https://phabricator.kde.org/source/krita/browse/master/COPYING))
 - [Pinta](https://pinta-project.com/) - Gtk# clone of Paint.NET. ([MIT](https://github.com/PintaProject/Pinta/blob/master/license-mit.txt))


### PR DESCRIPTION
**ImageToolkit** — Free browser-based image tools for compression, resizing, format conversion, and cropping.

All processing happens client-side — images never leave the user's device.

- **Website:** https://dannycranmer.github.io/imagetoolkit/
- **Source:** https://github.com/dannycranmer/imagetoolkit
- **License:** MIT