### PR TITLE
Add PDF Toolbox — free browser-based PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Software in this list is distributed under terms that allow anyone to use, modif
 
 - [Cloverleaf](https://cloverleaf.app) - An open source app to replace your password manager without storing your passwords anywhere. ([MIT](https://github.com/cloverleaf/web/blob/master/LICENSE))
 - [Dnote](https://www.getdnote.com/) - A simple command line notebook with multi-device sync and web interface. ([GNU AGPLv3](https://github.com/dnote/dnote/blob/master/licenses/AGPLv3.txt))
+- [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools (compress, merge, split, convert). No uploads, no registration. ([MIT](https://github.com/hwlsniper/pdftoolbox/blob/master/LICENSE))
 - [DocuSeal](https://www.docuseal.co/) - A platform to fill and sign digital documents. ([GNU AGPLv3](https://github.com/docusealco/docuseal/blob/master/LICENSE))
 - [Etherpad](http://etherpad.org/) - Collaborative document editing in real-time. ([Apache License 2.0](https://github.com/ether/etherpad-lite/blob/develop/LICENSE))
 - [Ghost](https://ghost.org/) - Hackable platform for building and running online publications. ([MIT](https://github.com/TryGhost/Ghost/blob/master/LICENSE))


### PR DESCRIPTION
Free, open-source browser-based PDF tools. No uploads, no registration. https://pdftoolbox-three.vercel.app